### PR TITLE
Fix denominator in DiameterCritical for larger particles

### DIFF
--- a/lpt_oil.F90
+++ b/lpt_oil.F90
@@ -118,7 +118,7 @@
             B2 = Y1 - A2*X1
 
             ! Compute the critical diameter.
-            DiameterCritical = 10.D0**((B2-B1)/(A1-A1))
+            DiameterCritical = 10.D0**((B2-B1)/(A1-A2))
 
             ! Ellipsoidal shape, intermediate size range.
             IF(DiameterEffective.LE.DiameterCritical)THEN


### PR DESCRIPTION
Previously, DiameterCritical was 10.D0**((B2-B1)/(A1-A1)) which creates a division by zero error. I believe it should be

DiameterCritical = 10.D0**((B2-B1)/(A1-A2))

from Zheng and Yapa (2000)